### PR TITLE
Re-added missing has() method to the Versioner

### DIFF
--- a/src/Naneau/ProjectVersioner/Versioner.php
+++ b/src/Naneau/ProjectVersioner/Versioner.php
@@ -93,6 +93,23 @@ class Versioner
     }
 
     /**
+     * Does a directory have a version?
+     *
+     * @param string $directory
+     * @return bool
+     **/
+    public function has($directory)
+    {
+        foreach ($this->getReaders() as $reader) {
+            if ($reader->canRead($directory)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Get the set of readers
      *
      * @return Reader[]

--- a/tests/Reader/ComposerTest.php
+++ b/tests/Reader/ComposerTest.php
@@ -3,6 +3,7 @@
 use Naneau\ProjectVersioner\Versioner;
 use Naneau\ProjectVersioner\Reader\Composer as ComposerReader;
 use Naneau\ProjectVersioner\Reader\ComposerPackage as ComposerPackageReader;
+use Naneau\ProjectVersioner\Reader\ComposerJson as ComposerJsonReader;
 
 class ComposerTest extends \PHPUnit_Framework_TestCase
 {
@@ -26,5 +27,15 @@ class ComposerTest extends \PHPUnit_Framework_TestCase
         $versioner = new Versioner($readers);
 
         $this->assertEquals('v2.5.4', $versioner->get($directory));
+    }
+
+    public function testComposerJsonRead()
+    {
+        $directory = __DIR__ . '/../projects/composer';
+
+        $readers = array(new ComposerJsonReader);
+        $versioner = new Versioner($readers);
+
+        $this->assertEquals('1.0.0', $versioner->get($directory));
     }
 }

--- a/tests/Versioner/CombineReadersTest.php
+++ b/tests/Versioner/CombineReadersTest.php
@@ -79,4 +79,25 @@ class CombineReadersTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
+
+    public function testHasAVersion()
+    {
+        $versioner = new Versioner;
+
+        // This one should have a version
+        $versioner->setReaders(
+            array(new FileReader('VERSION'))
+        );
+        return $this->assertTrue(
+            $versioner->has(__DIR__ . '/../projects/composer-file/')
+        );
+
+        // Should not have a version
+        $versioner->setReaders(
+            array(new FileReader('FOO'))
+        );
+        return $this->assertFalse(
+            $versioner->has(__DIR__ . '/../projects/composer-file/')
+        );
+    }
 }

--- a/tests/projects/composer/composer.json
+++ b/tests/projects/composer/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "naneau/project-versioner",
+    "description": "A tool to maintain project/sub-project versions based on Composer, file mtimes, etc.",
+    "license": "MIT",
+    "version": "1.0.0",
+    "authors": [
+        {
+            "name": "Maurice Fonk",
+            "email": "maurice@naneau.net"
+        }
+    ],
+
+    "autoload": {
+        "psr-4": {"Naneau\\ProjectVersioner\\": "src/Naneau/ProjectVersioner/"}
+    },
+
+    "minimum-stability": "stable",
+    "require": {
+        "symfony/finder": "~2.5"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.2"
+    }
+}


### PR DESCRIPTION
- Re-added disappeared `Naneau\ProjectVersioner\Versioner::has($directory)` method. My best guess is that tag/commit https://github.com/naneau/php-project-versioner/commit/6a384a4a83efb62ce80a5cee9455e81c83f4dec6 was never pushed to the `master` branch since it is missing in everything (code, commits, PRs) except for tag `1.0.1`.
- Adding unit tests for composer.json reader and the has methods.
